### PR TITLE
Revert "Bump jersey-common from 2.29 to 2.37"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     compile('org.apache.commons:commons-lang3:3.9')
     compile('org.apache.jena:jena-arq:3.12.0')
     compile('org.glassfish.jersey.core:jersey-client:2.29')
-    compile('org.glassfish.jersey.core:jersey-common:2.37')
+    compile('org.glassfish.jersey.core:jersey-common:2.29')
     compile('org.jooq:jool-java-8:0.9.14')
     compile('org.projectlombok:lombok:1.18.8')
 


### PR DESCRIPTION
Reverts FINTLabs/fint-geointegrasjon-adapter#13

Regression in FintSse causes SSE connections to silently fail